### PR TITLE
Incremental loading of Github events and issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ curl -XPUT localhost:9200/_river/my_gh_river/_meta -d '{
 }'
 ```
 
-Interval is given in seconds and it changes how often the river looks for new data. Since 1.7.1 the default value has been reduced to one minute as we now only load issues and events that has changed, which should decrease API calls and improve the time to update quite significantly. The actual polling interval will be affected by GitHub's minimum allowed polling interval, which is normally 60 seconds, but may increase when servers are busy.
+_interval_ is optional, given in seconds and changes how often the river looks for new data. Since 1.7.1 the default value has been reduced to one minute as we now only load issues and events that has changed, which should decrease API calls and improve the time to update quite significantly. The actual polling interval will be affected by GitHub's minimum allowed polling interval, which is normally 60 seconds, but may increase when servers are busy.
 
-The authentication bit is optional. It helps with the API rate limit and when accessing private data. You can use your own GitHub credentials or a token. When using a token, fill in the token as the username and `x-oauth-basic` as the password, as the [docs](http://developer.github.com/v3/auth/#basic-authentication) mention.
+_authentication_ is optional and helps with the API rate limit (5000 requests/hour instead of 60 requests/hour) and when accessing private data. You can use your own GitHub credentials or a token. When using a token, fill in the token as the username and `x-oauth-basic` as the password, as the [docs](http://developer.github.com/v3/auth/#basic-authentication) mention.
+
+If you do not use _authentication_, you may want to set _interval_ to a higher value, like 900 (every 15 minutes), as the GitHub rate limit will probably be breached when using low values. This is __not__ recommended if you require the GitHub events without holes, as Github only allows access to the last 300 events. In that case, authenticating is highly recommended. _This will probably change in a later version, at least for repositories without too much traffic, as we should be able to check for changes before loading most types of entries._
 
 ##Deleting the river
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 elasticsearch-river-github
 ==========================
 
-_THIS IS NOT THE ORIGINAL REPOSITORY_
-You probably want https://github.com/uberVU/elasticsearch-river-github for the correct one. This is just a temporary repository for my own fixes.
-
 Elasticsearch river for GitHub data. Fetches all of the following for
 a given GitHub repo:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 elasticsearch-river-github
 ==========================
 
-_THIS IS NOT THE ORIGINAL REPOSITORY_  
+_THIS IS NOT THE ORIGINAL REPOSITORY_
 You probably want https://github.com/uberVU/elasticsearch-river-github for the correct one. This is just a temporary repository for my own fixes.
 
 Elasticsearch river for GitHub data. Fetches all of the following for

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 elasticsearch-river-github
 ==========================
 
-_THIS IS NOT THE ORIGINAL REPOSITORY_
+_THIS IS NOT THE ORIGINAL REPOSITORY_  
 You probably want https://github.com/uberVU/elasticsearch-river-github for the correct one. This is just a temporary repository for my own fixes.
 
 Elasticsearch river for GitHub data. Fetches all of the following for

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 elasticsearch-river-github
 ==========================
 
+_THIS IS NOT THE ORIGINAL REPOSITORY_
+You probably want https://github.com/uberVU/elasticsearch-river-github for the correct one. This is just a temporary repository for my own fixes.
+
 Elasticsearch river for GitHub data. Fetches all of the following for
 a given GitHub repo:
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Works for private repos as well if you provide authentication.
 Assuming you have elasticsearch's `bin` folder in your `PATH`:
 
 ```
-plugin -i com.ubervu/elasticsearch-river-github/1.7.0
+plugin -i com.ubervu/elasticsearch-river-github/1.7.1
 ```
 
 Otherwise, you have to find the directory yourself. It should be
@@ -32,7 +32,7 @@ curl -XPUT localhost:9200/_river/my_gh_river/_meta -d '{
     "github": {
         "owner": "gabrielfalcao",
         "repository": "lettuce",
-        "interval": 3600,
+        "interval": 60,
         "authentication": {
             "username": "MYUSER", # or token
             "password": "MYPASSWORD" # or x-oauth-basic when using a token
@@ -42,7 +42,7 @@ curl -XPUT localhost:9200/_river/my_gh_river/_meta -d '{
 }'
 ```
 
-Interval is given in seconds and it changes how often the river looks for new data.
+Interval is given in seconds and it changes how often the river looks for new data. Since 1.7.1 the default value has been reduced to one minute as we now only load issues and events that has changed, which should decrease API calls and improve the time to update quite significantly. The actual polling interval will be affected by GitHub's minimum allowed polling interval, which is normally 60 seconds, but may increase when servers are busy.
 
 The authentication bit is optional. It helps with the API rate limit and when accessing private data. You can use your own GitHub credentials or a token. When using a token, fill in the token as the username and `x-oauth-basic` as the password, as the [docs](http://developer.github.com/v3/auth/#basic-authentication) mention.
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 
     <build>
         <plugins>
-<!--            <plugin>
+           <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
                 <executions>
@@ -90,7 +90,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin> -->
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.ubervu</groupId>
     <artifactId>elasticsearch-river-github</artifactId>
-    <version>1.7.0</version>
+    <version>1.7.1</version>
     <packaging>jar</packaging>
     <description>Github River for ElasticSearch</description>
     <inceptionYear>2014</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 
     <build>
         <plugins>
-           <plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 
     <build>
         <plugins>
-<!--            <plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
                 <executions>
@@ -90,7 +90,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin> -->
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 
     <build>
         <plugins>
-            <plugin>
+<!--            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
                 <executions>
@@ -90,7 +90,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
+            </plugin> -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/src/main/java/com/ubervu/river/github/GitHubRiver.java
+++ b/src/main/java/com/ubervu/river/github/GitHubRiver.java
@@ -356,7 +356,7 @@ public class GitHubRiver extends AbstractRiverComponent implements River {
             if (totalEntries > 0) {
                 FilteredQueryBuilder updatedAtQuery = QueryBuilders
                         .filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders.existsFilter("created_at"));
-                FieldSortBuilder updatedAtSort = SortBuilders.fieldSort("_id").order(SortOrder.DESC);
+                FieldSortBuilder updatedAtSort = SortBuilders.fieldSort("created_at").order(SortOrder.DESC);
 
                 SearchResponse response = client.prepareSearch(index)
                         .setQuery(updatedAtQuery)


### PR DESCRIPTION
This is an attempt to use the ETag header and since parameter to make the polling more effecient.

Sorry about all the stupid commits (updating README, then revert, commenting GPG, then uncommenting again), not entirely used to working in a fork. :)

The changes aren't super pretty, but I wanted to keep as close to the original design as possible, which may have streched it a bit too far. I'm thinking we could introduce some kind of indexer or fetcher class/interface that could be subclassed for special cases like Events to help keeping track of ETags and state, but I'd like your opinion first.

Fixes #15 when merged.
